### PR TITLE
Add colored last-seen dots to dialogs

### DIFF
--- a/Telegram/CMakeLists.txt
+++ b/Telegram/CMakeLists.txt
@@ -727,6 +727,8 @@ PRIVATE
     data/data_histories.h
     data/data_history_messages.cpp
     data/data_history_messages.h
+    data/data_lastseen_badge.cpp
+    data/data_lastseen_badge.h
     data/data_lastseen_status.h
     data/data_location.cpp
     data/data_location.h

--- a/Telegram/Resources/langs/lang.strings
+++ b/Telegram/Resources/langs/lang.strings
@@ -553,6 +553,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 "lng_settings_uri_scheme_box_title" = "Custom URI Scheme";
 "lng_settings_uri_scheme_field_label" = "Example: potplayer://.";
 "lng_settings_last_seen_in_dialogs" = "Show last seen time in list of dialogs";
+"lng_settings_colored_last_seen_dots" = "Enable colored last seen dots";
 "lng_settings_search_engine" = "Add a 'Search Selected Text' to Context Menu";
 "lng_settings_search_engine_box_title" = "URL of Search Engine";
 "lng_settings_search_engine_field_label" = "URL must contain '%q'";

--- a/Telegram/SourceFiles/core/fork_settings.cpp
+++ b/Telegram/SourceFiles/core/fork_settings.cpp
@@ -29,7 +29,8 @@ QByteArray ForkSettings::serialize() const {
 		+ Serialize::stringSize(_searchEngineUrl)
 		+ sizeof(qint32) * 13
 		+ sizeof(qint32) * 2
-		+ Serialize::stringSize(_botsPlatforms);
+		+ Serialize::stringSize(_botsPlatforms)
+		+ sizeof(qint32);
 
 	auto result = QByteArray();
 	result.reserve(size);
@@ -62,6 +63,7 @@ QByteArray ForkSettings::serialize() const {
 			<< _botsPlatforms
 			<< qint32(_archivedStoriesAreHidden ? 1 : 0)
 			<< qint32(_hideFromBlockedUsers ? 1 : 0)
+			<< qint32(_coloredLastSeenDots ? 1 : 0)
 			;
 	}
 	return result;
@@ -99,6 +101,7 @@ void ForkSettings::addFromSerialized(const QByteArray &serialized) {
 	qint32 additionalButtonsWebBot = _additionalButtonsWebBot;
 	qint32 archivedStoriesAreHidden = _archivedStoriesAreHidden;
 	qint32 hideFromBlockedUsers = _hideFromBlockedUsers;
+	qint32 coloredLastSeenDots = _coloredLastSeenDots;
 	QString botsPlatforms = _botsPlatforms;
 
 	if (!stream.atEnd()) {
@@ -150,6 +153,9 @@ void ForkSettings::addFromSerialized(const QByteArray &serialized) {
 	if (!stream.atEnd()) {
 		stream >> hideFromBlockedUsers;
 	}
+	if (!stream.atEnd()) {
+		stream >> coloredLastSeenDots;
+	}
 	if (stream.status() != QDataStream::Ok) {
 		LOG(("App Error: "
 			"Bad data for Core::ForkSettings::constructFromSerialized()"));
@@ -181,6 +187,7 @@ void ForkSettings::addFromSerialized(const QByteArray &serialized) {
 	_additionalButtonsWebBot = (additionalButtonsWebBot == 1);
 	_archivedStoriesAreHidden = (archivedStoriesAreHidden == 1);
 	setHideFromBlockedUsers(hideFromBlockedUsers == 1);
+	_coloredLastSeenDots = (coloredLastSeenDots == 1);
 	_botsPlatforms = std::move(botsPlatforms);
 }
 
@@ -207,6 +214,15 @@ void ForkSettings::resetOnLastLogout() {
 	_archivedStoriesAreHidden = false;
 	setHideFromBlockedUsers(false);
 	_botsPlatforms = QString();
+	_coloredLastSeenDots = true;
+}
+
+void ForkSettings::setColoredLastSeenDots(bool newValue) {
+	if (_coloredLastSeenDots == newValue) {
+		return;
+	}
+	_coloredLastSeenDots = newValue;
+	_coloredLastSeenDotsChanges.fire({});
 }
 
 [[nodiscard]] bool ForkSettings::addToMenuRememberMedia() const {

--- a/Telegram/SourceFiles/core/fork_settings.h
+++ b/Telegram/SourceFiles/core/fork_settings.h
@@ -46,6 +46,13 @@ public:
 	void setLastSeenInDialogs(bool newValue) {
 		_lastSeenInDialogs = newValue;
 	}
+	[[nodiscard]] bool coloredLastSeenDots() const {
+		return _coloredLastSeenDots;
+	}
+	[[nodiscard]] rpl::producer<> coloredLastSeenDotsChanges() const {
+		return _coloredLastSeenDotsChanges.events();
+	}
+	void setColoredLastSeenDots(bool newValue);
 	[[nodiscard]] QString searchEngineUrl() const {
 		return _searchEngineUrl;
 	}
@@ -149,6 +156,8 @@ private:
 	QString _botsPlatforms;
 	bool _archivedStoriesAreHidden = false;
 	bool _hideFromBlockedUsers = false;
+	bool _coloredLastSeenDots = true;
+	rpl::event_stream<> _coloredLastSeenDotsChanges;
 
 };
 

--- a/Telegram/SourceFiles/data/data_lastseen_badge.cpp
+++ b/Telegram/SourceFiles/data/data_lastseen_badge.cpp
@@ -1,0 +1,65 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "data/data_lastseen_badge.h"
+
+#include "base/assertion.h"
+
+namespace Data {
+namespace {
+
+constexpr auto kRecentLimit = 15 * 60;
+constexpr auto kModerateLimit = 30 * 60;
+constexpr auto kStaleLimit = 60 * 60;
+
+} // namespace
+
+LastSeenBadge ClassifyLastSeenBadge(
+		LastseenStatus status,
+		TimeId now) {
+	if (status.isOnline(now)) {
+		return LastSeenBadge::Online;
+	} else if (status.isHidden()) {
+		return LastSeenBadge::None;
+	}
+	const auto till = status.onlineTill();
+	if (!till || till > now) {
+		return LastSeenBadge::None;
+	}
+	const auto elapsed = int64(now) - int64(till);
+	return (elapsed < kRecentLimit)
+		? LastSeenBadge::Recent
+		: (elapsed < kModerateLimit)
+		? LastSeenBadge::Moderate
+		: (elapsed < kStaleLimit)
+		? LastSeenBadge::Stale
+		: LastSeenBadge::None;
+}
+
+TimeId NextLastSeenBadgeChange(
+		LastseenStatus status,
+		TimeId now) {
+	const auto offset = [&] {
+		switch (ClassifyLastSeenBadge(status, now)) {
+		case LastSeenBadge::Recent: return kRecentLimit;
+		case LastSeenBadge::Moderate: return kModerateLimit;
+		case LastSeenBadge::Stale: return kStaleLimit;
+		case LastSeenBadge::None:
+		case LastSeenBadge::Online: return 0;
+		}
+		Unexpected("LastSeenBadge value in NextLastSeenBadgeChange.");
+	}();
+	if (!offset) {
+		return 0;
+	}
+	const auto next = int64(status.onlineTill()) + offset;
+	return (next <= std::numeric_limits<TimeId>::max())
+		? TimeId(next)
+		: 0;
+}
+
+} // namespace Data

--- a/Telegram/SourceFiles/data/data_lastseen_badge.h
+++ b/Telegram/SourceFiles/data/data_lastseen_badge.h
@@ -1,0 +1,33 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#pragma once
+
+#include "base/basic_types.h"
+
+#include <limits>
+
+#include "data/data_lastseen_status.h"
+
+namespace Data {
+
+enum class LastSeenBadge : uint8 {
+	None,
+	Online,
+	Recent,
+	Moderate,
+	Stale,
+};
+
+[[nodiscard]] LastSeenBadge ClassifyLastSeenBadge(
+	LastseenStatus status,
+	TimeId now);
+[[nodiscard]] TimeId NextLastSeenBadgeChange(
+	LastseenStatus status,
+	TimeId now);
+
+} // namespace Data

--- a/Telegram/SourceFiles/data/data_session.cpp
+++ b/Telegram/SourceFiles/data/data_session.cpp
@@ -331,6 +331,7 @@ Session::Session(not_null<Main::Session*> session)
 , _clearPhotoCacheDelayed([=] { clearScheduledPhotoCache(); })
 , _pollsClosingTimer([=] { checkPollsClosings(); })
 , _watchForOfflineTimer([=] { checkLocalUsersWentOffline(); })
+, _watchForLastSeenBadgeChangeTimer([=] { checkLastSeenBadgeChanges(); })
 , _groups(this)
 , _aiComposeTones(std::make_unique<AiComposeTones>(session))
 , _chatsFilters(std::make_unique<ChatFilters>(this))
@@ -1527,6 +1528,37 @@ void Session::maybeStopWatchForOffline(not_null<UserData*> user) {
 	}
 }
 
+void Session::watchForLastSeenBadgeChange(
+		not_null<UserData*> user,
+		TimeId now) {
+	if (!now) {
+		now = base::unixtime::now();
+	}
+	const auto lastseen = user->lastseen();
+	const auto badge = Data::ClassifyLastSeenBadge(lastseen, now);
+	if (badge == LastSeenBadge::None || badge == LastSeenBadge::Online) {
+		return;
+	}
+	const auto &[i, ok] = _watchingForLastSeenBadgeChange.emplace(
+		user,
+		badge);
+	if (!ok) {
+		if (i->second != badge) {
+			i->second = badge;
+		}
+	}
+	const auto next = Data::NextLastSeenBadgeChange(lastseen, now);
+	const auto timeout = (next - now) * crl::time(1000);
+	const auto fires = _watchForLastSeenBadgeChangeTimer.isActive()
+		? _watchForLastSeenBadgeChangeTimer.remainingTime()
+		: -1;
+	if (fires >= 0 && fires <= timeout) {
+		return;
+	}
+	_watchForLastSeenBadgeChangeTimer.callOnce(
+		std::max(timeout, crl::time(1)));
+}
+
 void Session::recordSharingDisabledTime(not_null<UserData*> user) {
 	_sharingDisabledTimes[user] = base::unixtime::now();
 }
@@ -1563,6 +1595,42 @@ void Session::checkLocalUsersWentOffline() {
 	}
 	if (!_watchingForOffline.empty()) {
 		_watchForOfflineTimer.callOnce(std::max(minimal, crl::time(1)));
+	}
+}
+
+void Session::checkLastSeenBadgeChanges() {
+	_watchForLastSeenBadgeChangeTimer.cancel();
+
+	auto minimal = 60 * 60 * crl::time(1000);
+	const auto now = base::unixtime::now();
+	auto changed = std::vector<not_null<UserData*>>();
+	for (auto i = begin(_watchingForLastSeenBadgeChange)
+		; i != end(_watchingForLastSeenBadgeChange);) {
+		const auto user = i->first;
+		const auto lastseen = user->lastseen();
+		const auto badge = Data::ClassifyLastSeenBadge(lastseen, now);
+		if (badge != i->second) {
+			changed.push_back(user);
+			i->second = badge;
+		}
+		const auto next = Data::NextLastSeenBadgeChange(lastseen, now);
+		if (!next) {
+			i = _watchingForLastSeenBadgeChange.erase(i);
+		} else {
+			accumulate_min(
+				minimal,
+				(next - now) * crl::time(1000));
+			++i;
+		}
+	}
+	if (!_watchingForLastSeenBadgeChange.empty()) {
+		_watchForLastSeenBadgeChangeTimer.callOnce(
+			std::max(minimal, crl::time(1)));
+	}
+	for (const auto user : changed) {
+		session().changes().peerUpdated(
+			user,
+			PeerUpdate::Flag::OnlineStatus);
 	}
 }
 

--- a/Telegram/SourceFiles/data/data_session.h
+++ b/Telegram/SourceFiles/data/data_session.h
@@ -11,6 +11,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "base/timer.h"
 #include "data/data_cloud_file.h"
 #include "data/data_groups.h"
+#include "data/data_lastseen_badge.h"
 #include "data/data_star_gift.h"
 #include "dialogs/dialogs_main_list.h"
 #include "history/history_location_manager.h"
@@ -307,6 +308,9 @@ public:
 
 	void watchForOffline(not_null<UserData*> user, TimeId now = 0);
 	void maybeStopWatchForOffline(not_null<UserData*> user);
+	void watchForLastSeenBadgeChange(
+		not_null<UserData*> user,
+		TimeId now = 0);
 
 	void recordSharingDisabledTime(not_null<UserData*> user);
 	[[nodiscard]] bool sharingRecentlyDisabledByMe(
@@ -1051,6 +1055,7 @@ private:
 	void setupUserIsContactViewer();
 
 	void checkLocalUsersWentOffline();
+	void checkLastSeenBadgeChanges();
 
 	void scheduleNextTTLs();
 	void checkTTLs();
@@ -1412,6 +1417,9 @@ private:
 
 	base::flat_map<not_null<UserData*>, TimeId> _watchingForOffline;
 	base::Timer _watchForOfflineTimer;
+	base::flat_map<not_null<UserData*>, LastSeenBadge>
+		_watchingForLastSeenBadgeChange;
+	base::Timer _watchForLastSeenBadgeChangeTimer;
 	base::flat_map<not_null<UserData*>, TimeId> _sharingDisabledTimes;
 
 	base::flat_map<not_null<PeerData*>, MTP::DcId> _peerStatsDcIds;

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -381,6 +381,13 @@ InnerWidget::InnerWidget(
 
 	setupOnlineStatusCheck();
 
+	Core::App().settings().fork().coloredLastSeenDotsChanges(
+	) | rpl::on_next([=] {
+		_rowsScrollCache.clear();
+		_cachedRows.clear();
+		update();
+	}, lifetime());
+
 	rpl::merge(
 		session().data().chatsListChanges(),
 		session().data().chatsListLoadedEvents()

--- a/Telegram/SourceFiles/dialogs/dialogs_row.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_row.cpp
@@ -20,6 +20,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "ui/text/text_options.h"
 #include "ui/text/text_utilities.h"
 #include "ui/painter.h"
+#include "core/application.h"
+#include "core/core_settings.h"
 #include "dialogs/dialogs_entry.h"
 #include "dialogs/ui/dialogs_video_userpic.h"
 #include "dialogs/ui/dialogs_layout.h"
@@ -27,6 +29,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "data/data_community.h"
 #include "data/data_folder.h"
 #include "data/data_forum.h"
+#include "data/data_lastseen_badge.h"
 #include "data/data_session.h"
 #include "data/data_stories.h"
 #include "data/data_peer_values.h"
@@ -45,6 +48,24 @@ constexpr auto kHiddenLayer = 2;
 constexpr auto kBottomLayer = 1;
 constexpr auto kNoneLayer = 0;
 constexpr auto kBlurRadius = 24;
+
+[[nodiscard]] Data::LastSeenBadge ResolveLastSeenBadge(
+		not_null<UserData*> user,
+		TimeId now,
+		bool insideCommunity) {
+	if (Data::IsUserOnline(user, now)) {
+		return Data::LastSeenBadge::Online;
+	} else if (insideCommunity
+		|| !Core::App().settings().fork().coloredLastSeenDots()
+		|| user->isSelf()
+		|| user->isBot()
+		|| user->isSupport()
+		|| user->isServiceUser()
+		|| user->linkedCommunityId()) {
+		return Data::LastSeenBadge::None;
+	}
+	return Data::ClassifyLastSeenBadge(user->lastseen(), now);
+}
 
 [[nodiscard]] int SubscriptionCutSkip() {
 	const auto width = st::dialogsSubscriptionBadgeOutlineTwice / 2.;
@@ -283,6 +304,12 @@ bool Row::CornerLayersManager::isSameLayer(Layer layer) const {
 	return isFinished() && (_nextLayer == layer);
 }
 
+bool Row::CornerLayersManager::isFadingOut(Layer layer) const {
+	return (_prevLayer == layer)
+		&& (_nextLayer != layer)
+		&& !isFinished();
+}
+
 void Row::CornerLayersManager::setLayer(
 		Layer layer,
 		Fn<void()> updateCallback) {
@@ -463,7 +490,7 @@ void Row::setCornerBadgeShown(
 	}
 }
 
-void Row::updateCornerBadgeShown(
+Data::LastSeenBadge Row::updateCornerBadgeShown(
 		not_null<PeerData*> peer,
 		Fn<void()> updateCallback,
 		bool hasUnreadBadgesAbove,
@@ -471,12 +498,15 @@ void Row::updateCornerBadgeShown(
 		bool hidden) const {
 	const auto user = peer->asUser();
 	const auto now = user ? base::unixtime::now() : TimeId();
+	const auto lastSeenBadge = user
+		? ResolveLastSeenBadge(user, now, insideCommunity)
+		: Data::LastSeenBadge::None;
 	const auto channel = user ? nullptr : peer->asChannel();
 	const auto nextLayer = [&] {
 		if (hasUnreadBadgesAbove) {
 			return kNoneLayer;
 		} else if (user
-			&& (Data::IsUserOnline(user, now)
+			&& (lastSeenBadge != Data::LastSeenBadge::None
 				|| (!insideCommunity && user->linkedCommunityId()))) {
 			return kTopLayer;
 		} else if (channel
@@ -492,9 +522,14 @@ void Row::updateCornerBadgeShown(
 		return kNoneLayer;
 	}();
 	setCornerBadgeShown(nextLayer, std::move(updateCallback));
-	if ((nextLayer == kTopLayer) && user) {
+	if (nextLayer != kTopLayer || !user) {
+		return Data::LastSeenBadge::None;
+	} else if (lastSeenBadge == Data::LastSeenBadge::Online) {
 		peer->owner().watchForOffline(user, now);
+	} else if (lastSeenBadge != Data::LastSeenBadge::None) {
+		peer->owner().watchForLastSeenBadgeChange(user, now);
 	}
+	return lastSeenBadge;
 }
 
 void Row::ensureCornerBadgeUserpic() const {
@@ -514,7 +549,8 @@ void Row::PaintCornerBadgeFrame(
 		const Ui::PaintContext &context,
 		bool subscribed,
 		bool communityMember,
-		bool hidden) {
+		bool hidden,
+		Data::LastSeenBadge lastSeenBadge) {
 	data->frame.fill(Qt::transparent);
 
 	Painter q(&data->frame);
@@ -689,9 +725,23 @@ void Row::PaintCornerBadgeFrame(
 	auto pen = QPen(Qt::transparent);
 	pen.setWidthF(stroke * topLayerProgress);
 	q.setPen(pen);
-	q.setBrush(data->active
-		? st::dialogsOnlineBadgeFgActive
-		: st::dialogsOnlineBadgeFg);
+	const auto badgeBrush = [&] {
+		switch (lastSeenBadge) {
+		case Data::LastSeenBadge::Recent:
+			return st::dialogsLastSeenBadgeRecent->b;
+		case Data::LastSeenBadge::Moderate:
+			return st::dialogsLastSeenBadgeModerate->b;
+		case Data::LastSeenBadge::Stale:
+			return st::dialogsLastSeenBadgeStale->b;
+		case Data::LastSeenBadge::None:
+		case Data::LastSeenBadge::Online:
+			return data->active
+				? st::dialogsOnlineBadgeFgActive->b
+				: st::dialogsOnlineBadgeFg->b;
+		}
+		Unexpected("LastSeenBadge value in PaintCornerBadgeFrame.");
+	}();
+	q.setBrush(badgeBrush);
 	q.drawEllipse(QRectF(
 		photoSize - skip.x() - size,
 		photoSize - skip.y() - size,
@@ -727,14 +777,14 @@ void Row::paintUserpic(
 	const auto hidden = peer
 		&& context.community
 		&& context.community->isHidden(peer);
-	if (peer) {
-		updateCornerBadgeShown(
+	const auto lastSeenBadge = peer
+		? updateCornerBadgeShown(
 			peer,
 			nullptr,
 			hasUnreadBadgesAbove,
 			insideCommunity,
-			hidden);
-	}
+			hidden)
+		: Data::LastSeenBadge::None;
 
 	const auto cornerBadgeShown = !_cornerBadgeUserpic
 		? _cornerBadgeShown
@@ -801,6 +851,13 @@ void Row::paintUserpic(
 	const auto paletteVersionReal = style::PaletteVersion();
 	const auto paletteVersion = (paletteVersionReal & ((1 << 17) - 1));
 	const auto active = context.active ? 1 : 0;
+	const auto lastSeenBadgeValue = uint8(lastSeenBadge);
+	const auto fadingOutLastSeenBadge = (lastSeenBadge
+		== Data::LastSeenBadge::None)
+		&& _cornerBadgeUserpic->layersManager.isFadingOut(kTopLayer);
+	const auto paintedLastSeenBadge = fadingOutLastSeenBadge
+		? Data::LastSeenBadge(_cornerBadgeUserpic->lastSeenBadge)
+		: lastSeenBadge;
 	const auto keyChanged = (_cornerBadgeUserpic->key != key)
 		|| (_cornerBadgeUserpic->paletteVersion != paletteVersion);
 	if (keyChanged) {
@@ -824,6 +881,7 @@ void Row::paintUserpic(
 		|| !_cornerBadgeUserpic->layersManager.isFinished()
 		|| (activeMatters && _cornerBadgeUserpic->active != active)
 		|| _cornerBadgeUserpic->hidden != (hidden ? 1 : 0)
+		|| _cornerBadgeUserpic->lastSeenBadge != lastSeenBadgeValue
 		|| _cornerBadgeUserpic->frameIndex != frameIndex
 		|| _cornerBadgeUserpic->storiesCount != storiesCount
 		|| _cornerBadgeUserpic->storiesUnreadCount != storiesUnreadCount
@@ -833,6 +891,9 @@ void Row::paintUserpic(
 		_cornerBadgeUserpic->paletteVersion = paletteVersion;
 		_cornerBadgeUserpic->active = active;
 		_cornerBadgeUserpic->hidden = hidden ? 1 : 0;
+		if (!fadingOutLastSeenBadge) {
+			_cornerBadgeUserpic->lastSeenBadge = lastSeenBadgeValue;
+		}
 		_cornerBadgeUserpic->storiesCount = storiesCount;
 		_cornerBadgeUserpic->storiesUnreadCount = storiesUnreadCount;
 		_cornerBadgeUserpic->storiesHasVideoStream = storiesHasVideoStream;
@@ -848,7 +909,8 @@ void Row::paintUserpic(
 			context,
 			subscribed,
 			communityMember,
-			hidden);
+			hidden,
+			paintedLastSeenBadge);
 	}
 	p.drawImage(
 		context.st->padding.left() - framePadding,

--- a/Telegram/SourceFiles/dialogs/dialogs_row.h
+++ b/Telegram/SourceFiles/dialogs/dialogs_row.h
@@ -18,6 +18,10 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 class History;
 class HistoryItem;
 
+namespace Data {
+enum class LastSeenBadge : uint8;
+} // namespace Data
+
 namespace style {
 struct DialogRow;
 } // namespace style
@@ -102,7 +106,7 @@ public:
 	}
 	void recountHeight(float64 narrowRatio, FilterId filterId);
 
-	void updateCornerBadgeShown(
+	Data::LastSeenBadge updateCornerBadgeShown(
 		not_null<PeerData*> peer,
 		Fn<void()> updateCallback = nullptr,
 		bool hasUnreadBadgesAbove = false,
@@ -164,6 +168,7 @@ private:
 		CornerLayersManager();
 
 		[[nodiscard]] bool isSameLayer(Layer layer) const;
+		[[nodiscard]] bool isFadingOut(Layer layer) const;
 		[[nodiscard]] bool isDisplayedNone() const;
 		[[nodiscard]] float64 progressForLayer(Layer layer) const;
 		[[nodiscard]] float64 progress() const;
@@ -192,6 +197,7 @@ private:
 		uint32 storiesHasVideoStream : 1 = 0;
 		uint32 active : 1 = 0;
 		uint32 hidden : 1 = 0;
+		uint8 lastSeenBadge = 0;
 	};
 
 	void setCornerBadgeShown(
@@ -208,7 +214,8 @@ private:
 		const Ui::PaintContext &context,
 		bool subscribed,
 		bool communityMember,
-		bool hidden);
+		bool hidden,
+		Data::LastSeenBadge lastSeenBadge);
 
 	Key _id;
 	mutable std::unique_ptr<CornerBadgeUserpic> _cornerBadgeUserpic;

--- a/Telegram/SourceFiles/settings/sections/settings_fork.cpp
+++ b/Telegram/SourceFiles/settings/sections/settings_fork.cpp
@@ -466,6 +466,16 @@ void BuildForkSectionContent(SectionBuilder &builder) {
 		});
 
 	//
+	add(
+		u"fork/colored_last_seen_dots"_q,
+		{ u"colored"_q, u"last"_q, u"seen"_q, u"dots"_q, u"online"_q },
+		tr::lng_settings_colored_last_seen_dots(),
+		[] { return Core::App().settings().fork().coloredLastSeenDots(); },
+		[=](bool checked) {
+			Core::App().settings().fork().setColoredLastSeenDots(checked);
+		});
+
+	//
 	addWithBox(
 		u"fork/custom_search"_q,
 		{ u"custom"_q, u"search"_q, u"engine"_q },

--- a/Telegram/SourceFiles/tests/test_lastseen_badge.cpp
+++ b/Telegram/SourceFiles/tests/test_lastseen_badge.cpp
@@ -1,0 +1,119 @@
+/*
+This file is part of Telegram Desktop,
+the official desktop application for the Telegram messaging service.
+
+For license and copyright information please follow this link:
+https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+*/
+#include "data/data_lastseen_badge.h"
+
+#include <iostream>
+#include <limits>
+
+namespace {
+
+using Data::LastSeenBadge;
+using Data::LastseenStatus;
+
+constexpr auto kNow = TimeId(2'000'000'000);
+
+[[nodiscard]] bool Check(
+		LastseenStatus status,
+		LastSeenBadge expected,
+		TimeId next = 0) {
+	if (Data::ClassifyLastSeenBadge(status, kNow) != expected) {
+		return false;
+	}
+	return Data::NextLastSeenBadgeChange(status, kNow) == next;
+}
+
+[[nodiscard]] bool CheckRescheduledDeadline() {
+	const auto original = LastseenStatus::OnlineTill(kNow);
+	const auto changed = LastseenStatus::OnlineTill(kNow - 5 * 60);
+	if (Data::ClassifyLastSeenBadge(original, kNow)
+		!= LastSeenBadge::Recent
+		|| Data::ClassifyLastSeenBadge(changed, kNow)
+		!= LastSeenBadge::Recent) {
+		return false;
+	}
+	const auto originalTimeout = Data::NextLastSeenBadgeChange(
+		original,
+		kNow) - kNow;
+	const auto changedTimeout = Data::NextLastSeenBadgeChange(
+		changed,
+		kNow) - kNow;
+	return (changedTimeout < originalTimeout)
+		&& (changedTimeout == 10 * 60);
+}
+
+} // namespace
+
+int main() {
+	const auto result = Check(
+		LastseenStatus::OnlineTill(kNow + 1),
+		LastSeenBadge::Online)
+		&& Check(
+			LastseenStatus::OnlineTill(
+				std::numeric_limits<TimeId>::max()),
+			LastSeenBadge::Online)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow + 1, true),
+			LastSeenBadge::Online)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow),
+			LastSeenBadge::Recent,
+			kNow + 15 * 60)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - (15 * 60 - 1)),
+			LastSeenBadge::Recent,
+			kNow + 1)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - 15 * 60),
+			LastSeenBadge::Moderate,
+			kNow + 15 * 60)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - (15 * 60 + 1)),
+			LastSeenBadge::Moderate,
+			kNow + 15 * 60 - 1)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - (30 * 60 - 1)),
+			LastSeenBadge::Moderate,
+			kNow + 1)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - 30 * 60),
+			LastSeenBadge::Stale,
+			kNow + 30 * 60)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - (30 * 60 + 1)),
+			LastSeenBadge::Stale,
+			kNow + 30 * 60 - 1)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - (60 * 60 - 1)),
+			LastSeenBadge::Stale,
+			kNow + 1)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - 60 * 60),
+			LastSeenBadge::None)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - (60 * 60 + 1)),
+			LastSeenBadge::None)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - 24 * 60 * 60),
+			LastSeenBadge::None)
+		&& Check(
+			LastseenStatus::OnlineTill(kNow - 1, true),
+			LastSeenBadge::None)
+		&& Check(LastseenStatus::Recently(), LastSeenBadge::None)
+		&& Check(LastseenStatus::WithinWeek(), LastSeenBadge::None)
+		&& Check(LastseenStatus::WithinMonth(), LastSeenBadge::None)
+		&& Check(LastseenStatus::LongAgo(), LastSeenBadge::None)
+		&& Check(LastseenStatus::OnlineTill(1), LastSeenBadge::None)
+		&& Check(LastseenStatus(), LastSeenBadge::None)
+		&& CheckRescheduledDeadline();
+	if (!result) {
+		std::cerr << "Last-seen badge classification test failed.\n";
+		return 1;
+	}
+	std::cout << "Last-seen badge classification tests passed.\n";
+	return 0;
+}

--- a/Telegram/cmake/tests.cmake
+++ b/Telegram/cmake/tests.cmake
@@ -43,6 +43,27 @@ add_dependencies(Telegram test_text)
 
 target_prepare_qrc(test_text)
 
+add_executable(test_lastseen_badge)
+init_target(test_lastseen_badge "(tests)")
+
+target_include_directories(test_lastseen_badge PRIVATE ${src_loc})
+
+nice_target_sources(test_lastseen_badge ${src_loc}
+PRIVATE
+    data/data_lastseen_badge.cpp
+    data/data_lastseen_badge.h
+    data/data_lastseen_status.h
+    tests/test_lastseen_badge.cpp
+)
+
+target_link_libraries(test_lastseen_badge
+PRIVATE
+    desktop-app::lib_base
+)
+
+set_target_properties(test_lastseen_badge PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
 if (APPLE)
     add_custom_command(TARGET test_text POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory


### PR DESCRIPTION
## Summary

Adds optional colored last-seen dots to dialog avatars, matching Forkgram Android's thresholds:

- Recent (under 15 minutes): yellow
- Moderate (under 30 minutes): orange
- Stale (under 60 minutes): red
- Online/future status: existing green dot

The setting is enabled by default and can be toggled in Forkgram Settings. Hidden or approximate statuses, bots, service accounts, and timestamps at least 60 minutes old do not receive an offline-colored dot.

## Dependency

Draft until https://github.com/forkgram/lib_ui/pull/1 is merged.

That PR adds the three palette tokens referenced by this branch. The Desktop submodule currently points to its rebased commit `31fde03` on top of the latest official `lib_ui` base.

## Implementation notes

- Uses one shared session timer for all watched users.
- Recomputes deadlines when an exact timestamp changes within the same color bucket.
- Invalidates dialog rows when thresholds or the setting change.
- Preserves the outgoing badge color during fade-out, avoiding a brief green flash on colored-to-none transitions.
- Includes a focused classifier and scheduling regression test.

## Verification

- Rebased onto Forkgram Desktop `dev` at v7.2.5 (`45f04355f60b8c9489412bddfcff1677407c359b`).
- Focused Debug last-seen test passed.
- Incremental Windows x64 Release build passed.
- Release executable passed an isolated runtime smoke test.
- Windows x64 installer packaging passed.
- The feature was manually tested successfully before this rebase.

### Existing base-test mismatch

The 7.2.5 base's `test_update_verify` executable reports 57/58 because Forkgram's new embedded manifest intentionally defines `stable` and `beta`, while the inherited test still asserts that four Telegram channels exist. This feature branch does not modify the manifest, update verifier, or that test.